### PR TITLE
Depend on xapian-glib-2.0

### DIFF
--- a/dmodel/meson.build
+++ b/dmodel/meson.build
@@ -73,7 +73,7 @@ introspection_sources = [sources, enum_sources, installed_headers]
 gnome.generate_gir(main_library, extra_args: ['--warn-all', '--warn-error'],
     identifier_prefix: 'Dm', include_directories: include,
     includes: ['EosShard-0', 'Gio-2.0', 'GLib-2.0', 'GObject-2.0', 'Json-1.0',
-        'Soup-2.4', 'Xapian-1.0'],
+        'Soup-2.4', 'Xapian-2.0'],
     install: true, namespace: namespace_name, nsversion: api_version,
     sources: introspection_sources, symbol_prefix: 'dm')
 

--- a/meson.build
+++ b/meson.build
@@ -56,11 +56,11 @@ config = configuration_data()
 config.set_quoted('DM_VERSION', meson.project_version())
 configure_file(configuration: config, output: 'config.h')
 
-requires = ['glib-2.0', 'gio-2.0', 'gobject-2.0', 'json_glib-1.0', 'soup-2.4']
+requires = ['glib-2.0', 'gio-2.0', 'gobject-2.0', 'json-glib-1.0', 'libsoup-2.4']
 requires_private = [
     'endless-0 @0@'.format(libendless_req),
     'eos-shard-0 @0@'.format(shard_req),
-    'xapian_glib-2.0',
+    'xapian-glib-2.0',
 ]
 pkg.generate(filebase: api_name, libraries: [main_library],
     description: 'Software development kit for applications for the developing world',

--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,6 @@ endif
 
 libendless_req = '>= 0.5'
 shard_req = '>= 0.1.2'
-xapian_glib_req = '>= 1.7'
 
 gio = dependency('gio-2.0')
 glib = dependency('glib-2.0')
@@ -35,7 +34,7 @@ json_glib = dependency('json-glib-1.0')
 libendless = dependency('endless-0', version: libendless_req)
 shard = dependency('eos-shard-0', version: shard_req)
 soup = dependency('libsoup-2.4')
-xapian_glib = dependency('xapian-glib-1.0', version: xapian_glib_req)
+xapian_glib = dependency('xapian-glib-2.0')
 
 giomoduledir = gio.get_pkgconfig_variable('giomoduledir')
 
@@ -59,9 +58,9 @@ configure_file(configuration: config, output: 'config.h')
 
 requires = ['glib-2.0', 'gio-2.0', 'gobject-2.0', 'json_glib-1.0', 'soup-2.4']
 requires_private = [
-    'eos-shard-0 @0@'.format(shard_req),
-    'xapian_glib-1.0 @0@'.format(xapian_glib_req),
     'endless-0 @0@'.format(libendless_req),
+    'eos-shard-0 @0@'.format(shard_req),
+    'xapian_glib-2.0',
 ]
 pkg.generate(filebase: api_name, libraries: [main_library],
     description: 'Software development kit for applications for the developing world',

--- a/tests/dmodel/testQuery.js
+++ b/tests/dmodel/testQuery.js
@@ -1,3 +1,4 @@
+imports.gi.Xapian.version = '2.0';
 const {DModel, Xapian} = imports.gi;
 
 describe('Query', function () {


### PR DESCRIPTION
We're switching to a new version of Xapian, which means we're going to
be using a new version of the Xapian-GLib bindings.

https://phabricator.endlessm.com/T21655