### PR TITLE
build: Add dm-enums.h to main header

### DIFF
--- a/dmodel/dmodel.h
+++ b/dmodel/dmodel.h
@@ -15,6 +15,7 @@ G_BEGIN_DECLS
 #include "dm-dictionary-entry.h"
 #include "dm-domain.h"
 #include "dm-engine.h"
+#include "dm-enums.h"
 #include "dm-image.h"
 #include "dm-macros.h"
 #include "dm-media.h"


### PR DESCRIPTION
This was missing, and is required in order to be usable from C.

https://phabricator.endlessm.com/T21892