### PR TITLE
article: Default is-server-templated to TRUE

### DIFF
--- a/dmodel/dm-article.c
+++ b/dmodel/dm-article.c
@@ -230,7 +230,7 @@ dm_article_class_init (DmArticleClass *klass)
   dm_article_props[PROP_IS_SERVER_TEMPLATED] =
     g_param_spec_boolean ("is-server-templated", "Is Server Templated",
       "Is Server Templated",
-      FALSE, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+      TRUE, G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
   /**
    * DmArticle:authors:
    *


### PR DESCRIPTION
This makes sense because non-server-templated content is deprecated. For
the runtime it doesn't matter because all content metadata specifies
whether it is server-templated or not, but this is useful for testing.

https://phabricator.endlessm.com/T21272