### PR TITLE
Change 'ekn_id' to 'id' throughout

### DIFF
--- a/dmodel/dm-domain.c
+++ b/dmodel/dm-domain.c
@@ -539,13 +539,13 @@ dm_domain_get_shards (DmDomain *self)
 /**
  * dm_domain_test_link:
  * @self: the domain
- * @link: the ekn id of link to check for
+ * @link: the URI to check for
  * @error: #GError for error reporting.
  *
  * Attempts to determine if the given link corresponds to content within
  * this domain.
  *
- * Returns: (transfer full) (nullable): Returns an EKN URI to that content if
+ * Returns: (transfer full) (nullable): Returns an ID to that content if
  * so, and %NULL otherwise.
  */
 gchar *
@@ -591,12 +591,12 @@ on_metadata_stream_parsed (GObject *source,
 /**
  * dm_domain_get_object:
  * @self: the domain
- * @id: the ekn id of the object to load
+ * @id: the ID of the object to load
  * @cancellable: (allow-none): optional #GCancellable object, %NULL to ignore.
  * @callback: (scope async): callback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
  *
- * Asynchronously load an object model for the given ekn_id
+ * Asynchronously load an object model for the given ID
  */
 void
 dm_domain_get_object (DmDomain *self,

--- a/dmodel/dm-domain.h
+++ b/dmodel/dm-domain.h
@@ -19,12 +19,12 @@ G_DECLARE_FINAL_TYPE (DmDomain, dm_domain, DM, DOMAIN, GObject)
 /**
  * DmDomainError:
  * @DM_DOMAIN_ERROR_APP_ID_NOT_SET: App id property not set on object
- * @DM_DOMAIN_ERROR_ID_NOT_FOUND: Requested ekn id object not found
+ * @DM_DOMAIN_ERROR_ID_NOT_FOUND: Requested ID not found
  * @DM_DOMAIN_ERROR_BAD_MANIFEST: Error found while parsing the manifest.json
  * @DM_DOMAIN_ERROR_BAD_RESULTS: Error found while parsing the results json from xapian
  * @DM_DOMAIN_ERROR_UNSUPPORTED_VERSION: Unsupported version of content found
  * @DM_DOMAIN_ERROR_PATH_NOT_FOUND: Provided path was not found
- * @DM_DOMAIN_ERROR_ID_NOT_VALID: Requested ekn id is not valid
+ * @DM_DOMAIN_ERROR_ID_NOT_VALID: Requested ID is not valid
  * @DM_DOMAIN_ERROR_EMPTY: Content is empty
  *
  * Error enumeration for domain related errors.

--- a/dmodel/dm-engine.c
+++ b/dmodel/dm-engine.c
@@ -141,13 +141,13 @@ dm_engine_init (DmEngine *self)
 /**
  * dm_engine_test_link:
  * @self: the engine
- * @link: the ekn id of link to check for
+ * @link: the URI to check for
  * @error: #GError for error reporting.
  *
  * Attempts to determine if the given link corresponds to content within
  * the default domain.
  *
- * Returns: (transfer full) (nullable): Returns an EKN URI to that content if
+ * Returns: (transfer full) (nullable): Returns an ID to that content if
  * so, and %NULL otherwise.
  */
 gchar *
@@ -163,14 +163,14 @@ dm_engine_test_link (DmEngine *self,
 /**
  * dm_engine_test_link_for_app:
  * @self: the engine
- * @link: the ekn id of link to check for
+ * @link: the URI to check for
  * @app_id: the id of the application to load the object from
  * @error: #GError for error reporting.
  *
  * Attempts to determine if the given link corresponds to content within
  * the domain for the given application id.
  *
- * Returns: (transfer full) (nullable): Returns an EKN URI to that content if
+ * Returns: (transfer full) (nullable): Returns an ID to that content if
  * so, and %NULL otherwise.
  */
 gchar *
@@ -193,7 +193,7 @@ dm_engine_test_link_for_app (DmEngine *self,
 /**
  * dm_engine_get_object:
  * @self: the engine
- * @id: the ekn id of the object to load
+ * @id: the ID of the object to load
  * @cancellable: (allow-none): optional #GCancellable object, %NULL to ignore.
  * @callback: (scope async): callback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -258,13 +258,13 @@ on_domain_object_finished (GObject *source,
 /**
  * dm_engine_get_object_for_app:
  * @self: the engine
- * @id: the ekn id of the object to load
+ * @id: the ID of the object to load
  * @app_id: the id of the application to load the object from
  * @cancellable: (allow-none): optional #GCancellable object, %NULL to ignore.
  * @callback: (scope async): callback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
  *
- * Asynchronously load an object model for the given ekn_id
+ * Asynchronously load an object model for the given ID
  */
 void
 dm_engine_get_object_for_app (DmEngine *self,

--- a/dmodel/dm-query.c
+++ b/dmodel/dm-query.c
@@ -449,23 +449,23 @@ dm_query_class_init (DmQueryClass *klass)
   /**
    * DmQuery:ids:
    *
-   * A list of specific ekn ids to limit the search to. Can be used with an
+   * A list of specific IDs to limit the search to. Can be used with an
    * empty query to retrieve the given set of ids.
    */
   dm_query_props[PROP_IDS] =
     g_param_spec_boxed ("ids", "Ids",
-      "A list of model ids",
+      "A list of specific IDs to limit the search to",
       G_TYPE_STRV,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   /**
    * DmQuery:excluded-ids:
    *
-   * A list of specific ekn ids to exclude from the search.
+   * A list of specific IDs to exclude from the search.
    */
   dm_query_props[PROP_EXCLUDED_IDS] =
     g_param_spec_boxed ("excluded-ids", "Excluded ids",
-      "A list of specific ekn ids to exclude from the search",
+      "A list of specific IDs to exclude from the search",
       G_TYPE_STRV,
       G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 

--- a/dmodel/dm-utils-private.h
+++ b/dmodel/dm-utils-private.h
@@ -16,6 +16,6 @@ void
 dm_utils_free_gparam_array (GArray *params);
 
 const gchar *
-dm_utils_id_get_hash (const char *ekn_id);
+dm_utils_id_get_hash (const char *id);
 
 G_END_DECLS

--- a/dmodel/dm-utils.c
+++ b/dmodel/dm-utils.c
@@ -256,36 +256,36 @@ dm_utils_free_gparam_array (GArray *params)
   g_array_free (params, TRUE);
 }
 
-#define EKN_ID_REGEX "^ekn://[^/]*/(?=[A-Za-z0-9]*)(?:.{16}|.{40})$"
+#define ID_REGEX "^ekn://[^/]*/(?=[A-Za-z0-9]*)(?:.{16}|.{40})$"
 /**
  * dm_utils_is_valid_id:
- * @ekn_id: the ekn id
+ * @id: the ID
  *
- * Checks if an ekn id is valid.
+ * Checks if a document ID is valid (see #DmContent:id).
  *
- * Returns: true if the ekn id is valid.
+ * Returns: %TRUE if the ID is valid.
  */
 gboolean
-dm_utils_is_valid_id (const char *ekn_id)
+dm_utils_is_valid_id (const char *id)
 {
-  g_autoptr(GRegex) ekn_id_regex = g_regex_new (EKN_ID_REGEX, 0, 0, NULL);
-  return g_regex_match (ekn_id_regex, ekn_id, 0, NULL);
+  g_autoptr(GRegex) id_regex = g_regex_new (ID_REGEX, 0, 0, NULL);
+  return g_regex_match (id_regex, id, 0, NULL);
 }
 
 /**
  * dm_utils_id_get_hash:
- * @ekn_id: the ekn id
+ * @id: the ID
  *
- * Gets a pointer to the hash part of an ekn id.
+ * Gets a pointer to the hash part of an ID.
  *
- * Returns: (transfer none): a pointer to the hash part of the ekn id.
+ * Returns: (transfer none): a pointer to the hash part of the ID, within @id.
  */
 const gchar *
-dm_utils_id_get_hash (const char *ekn_id)
+dm_utils_id_get_hash (const char *id)
 {
-  if (!dm_utils_is_valid_id (ekn_id))
+  if (!dm_utils_is_valid_id (id))
     return NULL;
-  const gchar *post_uri = ekn_id + strlen ("ekn://");
+  const char *post_uri = id + strlen ("ekn://");
   return g_strstr_len (post_uri, -1, "/") + 1;
 }
 

--- a/dmodel/dm-utils.h
+++ b/dmodel/dm-utils.h
@@ -39,7 +39,7 @@ dm_default_vfs_set_shards (GSList *shards);
 
 DM_AVAILABLE_IN_ALL
 gboolean
-dm_utils_is_valid_id (const char *ekn_id);
+dm_utils_is_valid_id (const char *id);
 
 DM_AVAILABLE_IN_ALL
 GFile *

--- a/tests/dmodel/testArticle.js
+++ b/tests/dmodel/testArticle.js
@@ -9,7 +9,7 @@ describe ('Article Object Model', function () {
         jasmine.addMatchers(InstanceOfMatcher.customMatchers);
 
         jsonld = {
-            '@id': 'ekn:asoiaf/House_Greyjoy',
+            '@id': 'ekn:///01234567890123456789',
             'title': 'House Greyjoy',
             'synopsis': 'We Do Not Sow',
             'authors': ['Dalton Greyjoy', 'Dagon Greyjoy'],
@@ -20,7 +20,7 @@ describe ('Article Object Model', function () {
                     'hasIndex': 0,
                     'hasIndexLabel': '1',
                     'hasLabel': 'History',
-                    'hasContent': 'ekn://asoiaf/House_Greyjoy#History'
+                    'hasContent': 'ekn:///01234567890123456789#History'
                 },
             ],
         };

--- a/tests/dmodel/testContent.js
+++ b/tests/dmodel/testContent.js
@@ -1,7 +1,7 @@
 const {DModel} = imports.gi;
 
 const MOCK_CONTENT_DATA = {
-    '@id': 'ekn:text_editors/Emacs',
+    '@id': 'ekn:///12345678901234567890',
     'title': 'Emacs',
     'originalURI': 'http://en.wikipedia.org/wiki/Emacs',
     'language': 'pt-BR',
@@ -9,8 +9,8 @@ const MOCK_CONTENT_DATA = {
     'lastModifiedDate': '2013-05-09T04:12:44',
     'tags': ['uninstall plz', 'awful', 'butterflies'],
     'license': 'Creative-Commons',
-    'thumbnail': 'ekn://text_editors/Stallman.jpg',
-    'resources': ['ekn://text_editors/stallman_the_bard', 'ekn://text_editors/emacs_screenshot'],
+    'thumbnail': 'ekn:///34567890123456789012',
+    'resources': ['ekn:///45678901234567890123', 'ekn:///56789012345678901234'],
     'featured': true,
     'discoveryFeedContent': {'blurbs':
         ['10 Facts About Emacs That Will Blow Your Mind. #7 Knocked My Socks Off!'],
@@ -22,7 +22,7 @@ describe('Content Object Model', function () {
 
     it('successfully creates new object from properties', function () {
         contentObject = DModel.Content.new_from_props({
-            id: 'ekn:text_editors/Emacs',
+            id: 'ekn:///12345678901234567890',
             title : 'Emacs',
         });
         expect(contentObject.title).toEqual('Emacs');

--- a/tests/dmodel/testContent.js
+++ b/tests/dmodel/testContent.js
@@ -22,7 +22,7 @@ describe('Content Object Model', function () {
 
     it('successfully creates new object from properties', function () {
         contentObject = DModel.Content.new_from_props({
-            ekn_id : 'ekn:text_editors/Emacs',
+            id: 'ekn:text_editors/Emacs',
             title : 'Emacs',
         });
         expect(contentObject.title).toEqual('Emacs');
@@ -44,7 +44,7 @@ describe('Content Object Model', function () {
 
     it('successfully creates a new object with no info at all', function () {
         contentObject = DModel.Content.new_from_props();
-        expect(contentObject.ekn_id.startsWith('ekn:///')).toBeTruthy();
+        expect(contentObject.id.startsWith('ekn:///')).toBeTruthy();
     });
 
     describe ('properties', function () {
@@ -53,7 +53,7 @@ describe('Content Object Model', function () {
         });
 
         it('should have an ID', function () {
-            expect(contentObject.ekn_id).toEqual(MOCK_CONTENT_DATA['@id']);
+            expect(contentObject.id).toEqual(MOCK_CONTENT_DATA['@id']);
         });
 
         it('should have a title', function () {

--- a/tests/dmodel/testDictionaryEntry.js
+++ b/tests/dmodel/testDictionaryEntry.js
@@ -9,7 +9,7 @@ describe('Dictionary Object Model', function() {
         jasmine.addMatchers(InstanceOfMatcher.customMatchers);
 
         jsonld = {
-            '@id': 'ekn:word/Entreaty',
+            '@id': 'ekn:///23456789012345678901',
             'word': 'entreaty',
             'definition': 'An earnest request or petition; a plea.',
             'partOfSpeech': 'noun',

--- a/tests/dmodel/testEngine.js
+++ b/tests/dmodel/testEngine.js
@@ -47,7 +47,7 @@ describe('Engine', function () {
     });
 
     describe('get_object_for_app', function () {
-        it('returns a model for valid app id, ekn id pair', function (done) {
+        it('returns a model for valid (app ID, ID) pair', function (done) {
             engine.get_object_for_app('ekn:///02463d24cb5690af2c8e898736ea8c80e0e77077',
                                       'com.endlessm.fake_test_app.en',
                                       null,
@@ -94,7 +94,7 @@ describe('Engine', function () {
             }).toThrow();
         });
 
-        it('return null for an ekn id that does not exist', function () {
+        it('returns null for an ID that does not exist', function () {
             let id = engine.test_link_for_app('http://www.bbc.com/news/',
                                               'com.endlessm.fake_test_app.en');
             expect(id).toBe(null);
@@ -115,7 +115,7 @@ describe('Engine', function () {
         });
 
         describe('get_object', function () {
-            it('returns a model for valid ekn id', function () {
+            it('returns a model for valid ID', function () {
                 engine.get_object('ekn:///02463d24cb5690af2c8e898736ea8c80e0e77077',
                                   null,
                                   function (engine, result) {

--- a/tests/dmodel/testImage.js
+++ b/tests/dmodel/testImage.js
@@ -3,7 +3,7 @@ const {DModel} = imports.gi;
 const InstanceOfMatcher = imports.tests.InstanceOfMatcher;
 
 const MOCK_IMAGE_DATA = {
-    '@id': 'ekn://rick/astley',
+    '@id': 'ekn:///67890123456789012345',
     'title': 'Rick Astley: The Man, The Myth, The Legend',
     'caption': 'Great musician, or greatest?',
     'height': '666',

--- a/tests/dmodel/testMedia.js
+++ b/tests/dmodel/testMedia.js
@@ -3,12 +3,12 @@ const {DModel} = imports.gi;
 const InstanceOfMatcher = imports.tests.InstanceOfMatcher;
 
 const MOCK_MEDIA_DATA = {
-    '@id': 'ekn://rick/astley',
+    '@id': 'ekn:///67890123456789012345',
     'title': 'Rick Astley: The Man, The Myth, The Legend',
     'caption': 'Great musician, or greatest?',
     'height': '666',
     'width': '666',
-    'parent': 'ekn://paul/banks',
+    'parent': 'ekn:///78901234567890123456',
 };
 
 describe('Media Object Model', function () {

--- a/tests/dmodel/testQueryResults.js
+++ b/tests/dmodel/testQueryResults.js
@@ -1,12 +1,11 @@
 const {DModel} = imports.gi;
 
-const EXPECTED_EKN_IDS = ['ekn:///12345678', 'ekn:///87654321'];
+const EXPECTED_IDS = ['ekn:///12345678', 'ekn:///87654321'];
 
 describe('Query results', function () {
     let results;
     beforeEach(function () {
-        let models = EXPECTED_EKN_IDS.map(id =>
-            new DModel.Content({ ekn_id: id }));
+        let models = EXPECTED_IDS.map(id => new DModel.Content({id}));
         results = DModel.QueryResults.new_for_testing(models);
     });
 
@@ -20,11 +19,11 @@ describe('Query results', function () {
 
     it('can access its results list by getter', function () {
         let list = results.get_models();
-        expect(list.map(model => model.ekn_id)).toEqual(EXPECTED_EKN_IDS);
+        expect(list.map(({id}) => id)).toEqual(EXPECTED_IDS);
     });
 
     it('can access its results list by property', function () {
         let list = results.models;
-        expect(list.map(model => model.ekn_id)).toEqual(EXPECTED_EKN_IDS);
+        expect(list.map(({id}) => id)).toEqual(EXPECTED_IDS);
     });
 });

--- a/tests/dmodel/testSet.js
+++ b/tests/dmodel/testSet.js
@@ -5,7 +5,7 @@ describe('Set object model', function () {
 
     beforeEach(function () {
         jsonld = {
-            '@id': 'ekn://physics-en/ba750fd50f18382198e7876c6eb3b95a4759cf12',
+            '@id': 'ekn:///ba750fd50f18382198e7876c6eb3b95a4759cf12',
             '@type': 'ekn://_vocab/SetObject',
             '@context': 'ekn://_context/SetObject',
             tags: ['EknHomePageTag', 'EknSetObject'],

--- a/tests/dmodel/testVideo.js
+++ b/tests/dmodel/testVideo.js
@@ -3,14 +3,14 @@ const {DModel} = imports.gi;
 const InstanceOfMatcher = imports.tests.InstanceOfMatcher;
 
 const MOCK_VIDEO_DATA = {
-    '@id': 'ekn://rick/never',
+    '@id': 'ekn:///78901234567890123456',
     'title': 'Never Gonna Give You Up (Never Gonna Let You Down)',
     'caption': 'If this song was sushi, it would be a Rick Roll',
     'transcript': 'We\'re no strangers to love, etc etc etc',
     'duration': '666',
     'height': '666',
     'width': '666',
-    'poster': 'ekn://rick/poster',
+    'poster': 'ekn:///89012345678901234567',
 };
 
 describe('Video Object Model', function () {
@@ -35,7 +35,7 @@ describe('Video Object Model', function () {
         it('should marshal properties', function () {
             expect(videoObject.duration).toBe(666);
             expect(videoObject.transcript).toBe('We\'re no strangers to love, etc etc etc');
-            expect(videoObject.poster_uri).toBe('ekn://rick/poster');
+            expect(videoObject.poster_uri).toBe('ekn:///89012345678901234567');
         });
 
         it('should inherit properties set by parent class (DModel.Media)', function () {


### PR DESCRIPTION
EKN ID is a term closely connected with eos-knowledge-lib, and we'd like
to avoid that since the intention is to use libdmodel from other places.

(This still leaves ekn:// as the URI scheme, and the EKN_VERSION marker
file, but those probably need to stay so that we don't need to rebuild
the *entire* world.)

https://phabricator.endlessm.com/T22103