### PR TITLE
Improve search behaviour for partial words

### DIFF
--- a/dmodel/dm-query.c
+++ b/dmodel/dm-query.c
@@ -17,11 +17,10 @@
 #define MAX_TERM_LENGTH 245
 
 #define XAPIAN_PREFIX_EXACT_TITLE "XEXACTS"
+#define XAPIAN_PREFIX_TITLE "S"
 #define XAPIAN_PREFIX_CONTENT_TYPE "T"
 #define XAPIAN_PREFIX_ID "Q"
 #define XAPIAN_PREFIX_TAG "K"
-
-#define QUERY_PARSER_PREFIX_TITLE "title:"
 
 #define XAPIAN_SYNTAX_REGEX "\\(|\\)|\\+|\\-|\\'|\\\""
 #define XAPIAN_TERM_REGEX "AND|OR|NOT|XOR|NEAR|ADJ"
@@ -577,50 +576,65 @@ get_title_clause (XapianQueryParser *qp,
                   GError **error_out)
 {
   g_autoptr(GError) error = NULL;
+  g_autoptr(XapianQuery) base_clause = NULL;
+  g_autoptr(XapianQuery) corrected_clause = NULL;
+  g_autoptr(XapianQuery) retval = NULL;
+
   guint terms_length = g_strv_length (terms);
   guint corrected_terms_length = corrected_terms != NULL
                                ? g_strv_length (corrected_terms)
                                : 0;
 
-  guint max_length = MAX (terms_length, corrected_terms_length);
+  g_auto(GStrv) parser_terms = g_new0 (gchar *, terms_length + 1);
+  g_auto(GStrv) corrected_parser_terms = g_new0 (gchar *, corrected_terms_length + 1);
 
-  g_auto(GStrv) title_terms = g_new0 (gchar *, max_length + 1);
-
-  for (guint i = 0; i < max_length; i++)
+  for (guint i = 0; i < terms_length; i++)
     {
-      g_autofree char *term = NULL;
-      if (i < terms_length)
-        term = g_strconcat (QUERY_PARSER_PREFIX_TITLE, terms[i], NULL);
-
-      g_autofree char *corrected_term = NULL;
-      if (i < corrected_terms_length)
-        corrected_term = g_strconcat (QUERY_PARSER_PREFIX_TITLE,
-                                      corrected_terms[i], NULL);
-
-      /* Discard duplicates */
-      if (g_strcmp0 (term, corrected_term) == 0)
-        g_clear_pointer (&corrected_term, g_free);
-
-      if (term != NULL && corrected_term != NULL)
-        title_terms[i] = g_strdup_printf ("(%s OR %s)", term, corrected_term);
-      else if (term != NULL)
-        title_terms[i] = g_steal_pointer (&term);
-      else
-        title_terms[i] = g_steal_pointer (&corrected_term);
+      gchar *term = terms[i];
+      if (term != NULL)
+        parser_terms[i] = g_strdup(term);
     }
 
-  g_autofree char *parser_string = g_strjoinv (" ", title_terms);
+  for (guint i = 0; i < corrected_terms_length; i++)
+    {
+      gchar *corrected_term = corrected_terms[i];
+      if (corrected_term != NULL)
+        corrected_parser_terms[i] = g_strdup(corrected_term);
+    }
 
-  g_autoptr(XapianQuery) retval =
-    xapian_query_parser_parse_query_full (qp, parser_string,
-                                          XAPIAN_QUERY_PARSER_FEATURE_DEFAULT |
-                                          XAPIAN_QUERY_PARSER_FEATURE_PARTIAL,
-                                          "", &error);
+  g_autofree gchar *parser_string = g_strjoinv (" ", parser_terms);
+  g_autofree gchar *corrected_parser_string = g_strjoinv (" ", corrected_parser_terms);
+
+  if (parser_string != NULL)
+    base_clause = xapian_query_parser_parse_query_full (
+      qp, parser_string,
+      XAPIAN_QUERY_PARSER_FEATURE_DEFAULT | XAPIAN_QUERY_PARSER_FEATURE_PARTIAL,
+      XAPIAN_PREFIX_TITLE, &error);
+
   if (error != NULL)
     {
       g_propagate_error (error_out, error);
       return NULL;
     }
+
+  if (corrected_parser_string != NULL)
+    corrected_clause = xapian_query_parser_parse_query_full (
+      qp, corrected_parser_string,
+      XAPIAN_QUERY_PARSER_FEATURE_DEFAULT | XAPIAN_QUERY_PARSER_FEATURE_PARTIAL,
+      XAPIAN_PREFIX_TITLE, &error);
+
+  if (error != NULL)
+    {
+      g_propagate_error (error_out, error);
+      return NULL;
+    }
+
+  if (base_clause != NULL && corrected_clause != NULL)
+    retval = xapian_query_new_for_pair (XAPIAN_QUERY_OP_OR, base_clause, corrected_clause);
+  else if (base_clause != NULL)
+    retval = base_clause;
+  else
+    retval = corrected_clause;
 
   return g_steal_pointer (&retval);
 }

--- a/tests/dmodel/testQuery.js
+++ b/tests/dmodel/testQuery.js
@@ -166,7 +166,7 @@ describe('Query', function () {
                 mode: DModel.QueryMode.DELIMITED,
             });
             expect(query_obj.get_query(qp).get_description())
-                .toEqual('Query((XEXACTShappy_nwe_year@1 OR ((Shappy@1 OR (Snwe@2 OR Snew@3)) OR ((SYNONYM WILDCARD OR Syear) OR Syear@4))))');
+                .toEqual('Query((XEXACTShappy_nwe_year@1 OR (((Shappy@1 OR Snwe@2) OR ((SYNONYM WILDCARD OR Syear) OR Syear@3)) OR ((Shappy@1 OR Snew@2) OR ((SYNONYM WILDCARD OR Syear) OR Syear@3)))))');
         });
 
         it('filters requested IDs and tags', function () {
@@ -231,7 +231,7 @@ describe('Query', function () {
                 match: DModel.QueryMatch.TITLE_SYNOPSIS,
             });
             expect(query_obj.get_query(qp).get_description())
-                .toEqual('Query((((XEXACTSbeatles@1 OR (Sbeatles@1 OR Sbeetles@2)) OR ((SYNONYM WILDCARD OR beatles) OR beatles@1)) OR ((SYNONYM WILDCARD OR beetles) OR beetles@1)))')
+                .toEqual('Query((((XEXACTSbeatles@1 OR (((SYNONYM WILDCARD OR Sbeatles) OR Sbeatles@1) OR ((SYNONYM WILDCARD OR Sbeetles) OR Sbeetles@1))) OR ((SYNONYM WILDCARD OR beatles) OR beatles@1)) OR ((SYNONYM WILDCARD OR beetles) OR beetles@1)))')
         });
 
         it('stems terms if a stemmer is added to the query parser', function () {

--- a/tests/dmodel/testQuery.js
+++ b/tests/dmodel/testQuery.js
@@ -166,7 +166,7 @@ describe('Query', function () {
                 mode: DModel.QueryMode.DELIMITED,
             });
             expect(query_obj.get_query(qp).get_description())
-                .toEqual('Query((XEXACTShappy_nwe_year@1 OR (((Shappy@1 OR Snwe@2) OR ((SYNONYM WILDCARD OR Syear) OR Syear@3)) OR ((Shappy@1 OR Snew@2) OR ((SYNONYM WILDCARD OR Syear) OR Syear@3)))))');
+                .toEqual('Query((XEXACTShappy_nwe_year@1 OR (((Shappy@1 OR Snwe@2) OR ((SYNONYM WILDCARD OR Syear) OR Syear@3)) OR (Shappy@1 OR Snew@2 OR Syear@3))))');
         });
 
         it('filters requested IDs and tags', function () {
@@ -231,7 +231,7 @@ describe('Query', function () {
                 match: DModel.QueryMatch.TITLE_SYNOPSIS,
             });
             expect(query_obj.get_query(qp).get_description())
-                .toEqual('Query((((XEXACTSbeatles@1 OR (((SYNONYM WILDCARD OR Sbeatles) OR Sbeatles@1) OR ((SYNONYM WILDCARD OR Sbeetles) OR Sbeetles@1))) OR ((SYNONYM WILDCARD OR beatles) OR beatles@1)) OR ((SYNONYM WILDCARD OR beetles) OR beetles@1)))')
+                .toEqual('Query((((XEXACTSbeatles@1 OR (((SYNONYM WILDCARD OR Sbeatles) OR Sbeatles@1) OR Sbeetles@1)) OR ((SYNONYM WILDCARD OR beatles) OR beatles@1)) OR ((SYNONYM WILDCARD OR beetles) OR beetles@1)))');
         });
 
         it('stems terms if a stemmer is added to the query parser', function () {


### PR DESCRIPTION
This change breaks up raw and spell-corrected queries into two clauses,
each with FEATURE_PARTIAL, which are ORed together. It is necessary to
build them like this because FEATURE_PARTIAL does not work with a clause
which itself consists of boolean operators.

https://phabricator.endlessm.com/T27383